### PR TITLE
feat: minimal changes to remove PHP 8 deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/src/Object/BaseObject.php
+++ b/src/Object/BaseObject.php
@@ -6,7 +6,7 @@ use ImmobiliareLabs\BrazeSDK\ValidationInterface;
 
 abstract class BaseObject implements \JsonSerializable, ValidationInterface
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $dataToSerialize = array_filter(get_object_vars($this), function ($val) {
             return null !== $val;

--- a/src/Object/Messages/ApplePush.php
+++ b/src/Object/Messages/ApplePush.php
@@ -61,7 +61,7 @@ class ApplePush extends BaseRequest
     /** @var ?ApplePushActionButton[] */
     public $buttons;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $dataToSerialize = parent::jsonSerialize();
 

--- a/src/Object/UserAttributes.php
+++ b/src/Object/UserAttributes.php
@@ -103,7 +103,7 @@ class UserAttributes extends BaseObject
         }
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $dataToSerialize = parent::jsonSerialize();
 

--- a/src/Request/Campaigns/ListRequest.php
+++ b/src/Request/Campaigns/ListRequest.php
@@ -19,7 +19,7 @@ class ListRequest extends BaseRequest
     /** @var ?DateTimeInterface */
     public $last_edit_time_gt;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $dataToSerialize = parent::jsonSerialize();
 

--- a/src/Request/Canvas/ListRequest.php
+++ b/src/Request/Canvas/ListRequest.php
@@ -19,7 +19,7 @@ class ListRequest extends BaseRequest
     /** @var ?DateTimeInterface */
     public $last_edit_time_gt;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $dataToSerialize = parent::jsonSerialize();
 


### PR DESCRIPTION
Minimal changes to remove php8 deprecations.

@JellyBellyDev should we add types to all class properties for a 2.0 version?