### PR TITLE
Enable setting non-scalar types

### DIFF
--- a/src/Object/BaseObject.php
+++ b/src/Object/BaseObject.php
@@ -44,7 +44,7 @@ abstract class BaseObject implements \JsonSerializable, ValidationInterface
                 continue;
             }
 
-            if (is_scalar($paramValue)) {
+            if ((new \ReflectionProperty(static::class, $paramKey))->getType()->getName() === gettype($paramValue)) {
                 $this->$paramKey = $paramValue;
             }
         }

--- a/tests/Request/Users/TrackRequestTest.php
+++ b/tests/Request/Users/TrackRequestTest.php
@@ -63,6 +63,17 @@ class TrackRequestTest extends TestCase
         $trackRequest->validate(false);
     }
 
+    public function testFromArray(): void
+    {
+        $attributes = [ new UserAttributes() ];
+
+        $trackRequest = TrackRequest::fromArray([
+            'attributes' => $attributes
+        ]);
+
+        $this->assertSame($attributes, $trackRequest->attributes);
+    }
+
     public function validProvider(): array
     {
         $event1 = new Event();


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

Afternoon guys. 

Great package! We've just started integrating our platform with Braze and this has made life much easier and is a pleasure to work with! All the types are 👌🏻   

 I've stumbled on a potential issue when instantiating objects using the `fromArray` method. For example, I'd like to be able to create a `TrackRequest` as below but it's not currently possible as the `fillFromArray` method only sets scalar properties. 

```
$attribute1 = UserAttributes::fromArray([]);

$trackRequest = TrackRequest::fromArray([
    'attributes' => [ $attribute1 ]
]);
```

Is there a strong argument against being able to set a property like this or is it just an oversight? Created a PR for how a potential solution might look. What do you think?

Thanks again for your work on this package! 


## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor


