### PR TITLE
feat: add static as return type of BaseObject fromArray method

### DIFF
--- a/src/Object/BaseObject.php
+++ b/src/Object/BaseObject.php
@@ -21,12 +21,7 @@ abstract class BaseObject implements \JsonSerializable, ValidationInterface
         return $dataToSerialize;
     }
 
-    /**
-     * @todo: set return type to static when PHP 8.0 (or above) will be the minimum supported version
-     *
-     * @return static
-     */
-    public static function fromArray(array $params, bool $allowExtraProperties = false)
+    public static function fromArray(array $params, bool $allowExtraProperties = false): static
     {
         $instance = new static();
         $instance->fillFromArray($params, $allowExtraProperties);


### PR DESCRIPTION
## 🚨 Proposed changes

From PHP 8.0 static return type is allowed. Since 8.0 is now the minimum version we can now use it.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [x] Refactor
