### PR TITLE
fix: added type to attributes property of Recipient

### DIFF
--- a/src/Object/Recipient.php
+++ b/src/Object/Recipient.php
@@ -15,27 +15,26 @@ class Recipient extends BaseObject
 
     /**
      * Only for campaigns and messages
-     *
      */
     public ?array $trigger_properties = null;
 
     /**
      * Only for canvas
-     *
      */
     public ?array $canvas_entry_properties = null;
 
     /**
-     * Not included in documentation. Maybe available only on /campaigns/trigger/send endpoint
-     *
+     * Not well documented.
+     * Maybe available only on /campaigns/trigger/send and /canvas/trigger/send endpoints.
      */
     public ?bool $send_to_existing_only = null;
 
     /**
-     * Not included in documentation. Maybe available only on /campaigns/trigger/send endpoint
-     *
+     * Not well documented.
+     * Maybe available only on /campaigns/trigger/send and /canvas/trigger/send endpoints.
+     * We may remove the array type in the next major release.
      */
-    public ?array $attributes = null;
+    public array|UserAttributes|null $attributes = null;
 
     public function validate(bool $strict): void
     {


### PR DESCRIPTION
## 🚨 Proposed changes

Let's add an allowed type to the `attributes` property of `Recipient`, so we can use the `UserAttributes` object directly.
In the future we may remove the `array` type for better typing.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
