### PR TITLE
feat(ci): add create release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    name: Create changelog
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v5
+        with:
+          preset: conventionalcommits
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-user-name: ${{ github.actor }}
+          git-user-email: ${{ github.actor }}@users.noreply.github.com
+          tag-prefix: 'v'
+          input-file: 'CHANGELOG.md'
+          output-file: 'CHANGELOG.md'
+          skip-on-empty: false
+          skip-version-file: true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
-# Changelog
-All notable changes to this project will be documented in this file.
+## [2.2.1] - 2023-12-19
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+### Changed
+- chore: add workflows pipeline for php 8.2 
+- fix: added type to attributes property of Recipient
 
 
-## [Unreleased]
+## [2.2.0] - 2023-08-29 
+
+### Added
+- Add support for user custom attributes
+- Add support for /users/merge endpoint
+
+### Changed
+- Fix pull request template
+- Add static as return type of BaseObject fromArray method
+- Add properties to Subscription/GetStatusResponse class
+
+## [2.1.0] - 2023-05-11 
+
+### Added
+- Add new exceptions for client and server errors
+
+### Changed
+- Modified tests data provider to match properties types
 
 ## [2.0.0] - 2022-03-28
 ### Added
@@ -13,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Set minimum required PHP version to 8.0
+
+## [1.3.1] - 2023-08-29
+### Changed
+- Add properties to Subscription/GetStatusResponse class
+
+## [1.3.0] - 2023-05-05
+### Added
+- Add new exceptions for client and server errors
+
+### Changed
+- Modified tests data provider to match properties types
 
 ## [1.2.0] - 2022-03-28
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ composer test-coverage-html
 composer php-cs-fixer
 ```
 
+## Commit guidelines
+
+Please see the [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## Contributors
 
 Below the list of all contributors:


### PR DESCRIPTION
I tried this behavior in other my personal repository and I think that this is a correct configuration.

How it works: after this merge e in the feature when you would generate a new release go to tab actions, select "Create release" workflow and click on "Run workflow".

The workflow will do:

- choose new bump version (from conventional commits)
- update the file changelog
- commit file changelog updated
- push new tag and release tag

@antonioturdo would you like to try after the merge? 😄