### PR TITLE
feat: add support for http messages v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "symfony/http-client-contracts": "^2.4 || ^3.0"
     },
     "require-dev": {

--- a/tests/ClientAdapter/Psr18AdapterTest.php
+++ b/tests/ClientAdapter/Psr18AdapterTest.php
@@ -7,6 +7,7 @@ use ImmobiliareLabs\BrazeSDK\Exception\ClientException;
 use ImmobiliareLabs\BrazeSDK\Exception\NotValidBaseURIException;
 use ImmobiliareLabs\BrazeSDK\Exception\TransportException;
 use ImmobiliareLabs\BrazeSDK\Region;
+use Nyholm\Psr7\Stream;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -140,7 +141,7 @@ class Psr18AdapterTest extends TestCase
 
         $httpResponseMock->expects($this->once())
             ->method('getBody')
-            ->willReturn('');
+            ->willReturn(Stream::create(''));
 
         $resolvedResponse = $this->psr18Adapter->resolveResponse($httpResponseMock);
 


### PR DESCRIPTION
## 🚨 Proposed changes

Add support for `psr/http-message` v2 for compatibility whit sf 6.4 and php 8.1

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
