### PR TITLE
fix: allows to set a custom attribute to null

### DIFF
--- a/src/Object/UserAttributes.php
+++ b/src/Object/UserAttributes.php
@@ -94,7 +94,7 @@ class UserAttributes extends BaseObject
      * Using a DateTime object it would not be possible to know if you want
      * to send a date that includes time or not.
      */
-    public function setCustomAttribute(string $key, array|bool|float|int|string $value): void
+    public function setCustomAttribute(string $key, array|bool|float|int|string|null $value): void
     {
         $this->_customAttributes[$key] = $value;
     }


### PR DESCRIPTION
## 🚨 Proposed changes

Allows to set a custom attribute to null to remove it.

Reference:
https://www.braze.com/docs/api/objects_filters/user_attributes_object

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
