### PR TITLE
fix: use template for response in ClientAdapterInterface

### DIFF
--- a/src/ClientAdapter/ClientAdapterInterface.php
+++ b/src/ClientAdapter/ClientAdapterInterface.php
@@ -8,6 +8,9 @@ use ImmobiliareLabs\BrazeSDK\Exception\ServerException;
 use ImmobiliareLabs\BrazeSDK\Exception\TransportException;
 use ImmobiliareLabs\BrazeSDK\Request\BaseRequest;
 
+/**
+ * @template THttpResponse of mixed
+ */
 interface ClientAdapterInterface
 {
     public function setBaseURI(string $baseURI): void;
@@ -17,7 +20,7 @@ interface ClientAdapterInterface
     /**
      * If the http client supports asynchronous calls this method should just place the call in a non-blocking way.
      *
-     * @return mixed the real response or a reference to it that will allow you to solve it later, for example a promise
+     * @return THttpResponse the real response or a reference to it that will allow you to solve it later, for example a promise
      *
      * @throws TransportException
      * @throws ServerException
@@ -26,7 +29,7 @@ interface ClientAdapterInterface
     public function makeRequest(string $method, string $path, ?string $body = null): mixed;
 
     /**
-     * @param mixed $httpResponse the real response or a reference to it. It's the value returned by the makeRequest method
+     * @param THttpResponse $httpResponse the real response or a reference to it. It's the value returned by the makeRequest method
      *
      * @throws TransportException
      * @throws ServerException

--- a/src/ClientAdapter/Psr18Adapter.php
+++ b/src/ClientAdapter/Psr18Adapter.php
@@ -15,6 +15,9 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @implements ClientAdapterInterface<ResponseInterface>
+ */
 class Psr18Adapter implements ClientAdapterInterface
 {
     private ClientInterface $client;
@@ -88,10 +91,7 @@ class Psr18Adapter implements ClientAdapterInterface
         }
     }
 
-    /**
-     * @param ResponseInterface $httpResponse
-     */
-    public function resolveResponse($httpResponse): ClientResolvedResponse
+    public function resolveResponse(mixed $httpResponse): ClientResolvedResponse
     {
         return new ClientResolvedResponse(
             $httpResponse->getStatusCode(),

--- a/src/ClientAdapter/SymfonyAdapter.php
+++ b/src/ClientAdapter/SymfonyAdapter.php
@@ -13,6 +13,9 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * @implements ClientAdapterInterface<ResponseInterface>
+ */
 class SymfonyAdapter implements ClientAdapterInterface
 {
     private HttpClientInterface $client;
@@ -56,10 +59,7 @@ class SymfonyAdapter implements ClientAdapterInterface
         }
     }
 
-    /**
-     * @param ResponseInterface $httpResponse
-     */
-    public function resolveResponse($httpResponse): ClientResolvedResponse
+    public function resolveResponse(mixed $httpResponse): ClientResolvedResponse
     {
         try {
             return new ClientResolvedResponse(


### PR DESCRIPTION
## 🚨 Proposed changes

Use phpdoc template for response object in ClientAdapterInterface.

## ⚙️ Types of changes

-   [x] Refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved and unified type annotations and docblocks across client adapter implementations to clarify response types.
  * Added implementation annotations to adapter classes for stronger static typing guidance.
  * Adjusted internal type hints while preserving public API and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->